### PR TITLE
SObject.field default mapping value follows SFDC API naming convention. ...

### DIFF
--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -17,6 +17,18 @@ module ActiveForce
 
     class << self
       delegate :where, :first, :last, :all, :find, :find_by, :count, :to => :query
+
+      private
+
+      ###
+      # Transforms +attribute+ to the conventional Salesforce API name.
+      #
+      # Example:
+      #   > default_api_name :some_attribute
+      #   => "Some_Attribute__c"
+      def default_api_name(attribute)
+        String(attribute).split('_').map(&:capitalize).join('_') << '__c'
+      end
     end
 
     # The table name to used to make queries.
@@ -104,7 +116,7 @@ module ActiveForce
       id?
     end
 
-    def self.field field_name, from: field_name.camelize, as: :string
+    def self.field field_name, from: default_api_name(field_name), as: :string
       mappings[field_name] = from
       attribute field_name, sf_type: as
     end

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -41,6 +41,10 @@ describe ActiveForce::SObject do
         expect(Whizbang.attribute_names).to include(name)
       end
     end
+
+    it "uses Salesforce API naming conventions by default" do
+      expect(Whizbang.mappings[:estimated_close_date]).to eq 'Estimated_Close_Date__c'
+    end
   end
 
   describe '#create' do

--- a/spec/support/whizbang.rb
+++ b/spec/support/whizbang.rb
@@ -6,5 +6,6 @@ class Whizbang < ActiveForce::SObject
   field :date,                 from: 'Date_Label'
   field :datetime,             from: 'DateTime_Label'
   field :picklist_multiselect, from: 'Picklist_Multiselect_Label'
+  field :estimated_close_date
 
 end


### PR DESCRIPTION
Fixes #14 

Provides a default mapping for `SObject.field` that follows Salesforce API naming conventions:

``` ruby
class Foo < ActiveForce::SObject
   field :some_attribute
end

Foo.mappings[:some_attribute]
=> "Some_Attribute__c"
```
