### PR TITLE
Fix Ruby 2.0 compatibility issue

### DIFF
--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -146,7 +146,7 @@ module ActiveForce
         value = read_attribute(attr)
         [sf_field, value] if value
       end
-      attrs.compact.to_h
+      Hash.new(attrs.compact)
     end
 
 
@@ -154,7 +154,7 @@ module ActiveForce
       attrs = changed_mappings.map do |attr, sf_field|
         [sf_field, read_attribute(attr)]
       end
-      attrs.to_h.merge('Id' => id)
+      Hash.new(attrs).merge('Id' => id)
     end
 
     def changed_mappings


### PR DESCRIPTION
Array#to_h isn't supported in 2.0. Travis builds were failing as a result
