### PR TITLE
Provide a default id field for all SObject subclasses #27

### DIFF
--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -17,7 +17,6 @@ module ActiveForce
 
     class_attribute :mappings, :table_name
 
-
     class << self
       extend Forwardable
       def_delegators :query, :where, :first, :last, :all, :find, :find_by, :count
@@ -36,6 +35,13 @@ module ActiveForce
 
       def custom_table_name
         self.name if STANDARD_TYPES.include? self.name
+      end
+
+      ###
+      # Provide each subclass with a default id field. Can be overridden
+      # in the subclass if needed
+      def inherited(subclass)
+        subclass.field :id, from: 'Id'
       end
     end
 

--- a/spec/active_force/association_spec.rb
+++ b/spec/active_force/association_spec.rb
@@ -92,7 +92,7 @@ describe ActiveForce::SObject do
   describe "belongs_to" do
 
     before do
-      allow(client).to receive(:query).and_return Restforce::Mash.new(id: 1)
+      allow(client).to receive(:query).and_return [Restforce::Mash.new(id: 1)]
     end
 
     it "should get the resource it belongs to" do
@@ -102,8 +102,8 @@ describe ActiveForce::SObject do
 
     it "should allow to pass a foreign key as options" do
       class Comment < ActiveForce::SObject
-	field :fancy_post_id, from: 'PostId'
-	belongs_to :post, foreign_key: :fancy_post_id
+      	field :fancy_post_id, from: 'PostId'
+      	belongs_to :post, foreign_key: :fancy_post_id
       end
       allow(comment).to receive(:fancy_post_id).and_return "2"
       expect(client).to receive(:query).with("SELECT Id FROM Post__c WHERE Id = '2' LIMIT 1")

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -43,6 +43,18 @@ describe ActiveForce::SObject do
     it "uses Salesforce API naming conventions by default" do
       expect(Whizbang.mappings[:estimated_close_date]).to eq 'Estimated_Close_Date__c'
     end
+
+    describe 'having an id' do
+      it 'has one by default' do
+        expect(Territory.new).to respond_to(:id)
+        expect(Territory.mappings[:id]).to eq 'Id'
+      end
+
+      it 'can be overridden' do
+        expect(Quota.new).to respond_to(:id)
+        expect(Quota.mappings[:id]).to eq 'Bar_Id__c'
+      end
+    end
   end
 
   describe '#update' do
@@ -114,5 +126,4 @@ describe ActiveForce::SObject do
       Whizbang.find_by id: 123, text: "foo"
     end
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,3 +6,8 @@ require 'restforce'
 require 'active_force'
 Dir["./spec/support/**/*"].sort.each { |f| require f }
 require 'pry'
+
+class Territory < ActiveForce::SObject; end
+class Quota < ActiveForce::SObject
+  field :id, from: 'Bar_Id__c'
+end


### PR DESCRIPTION
Fixes #27

Adds a default field called `id` (mapped to `Id`) to each subclass of `SObject`.

Change to association_spec was needed because the return value of `query` on a Restforce client returns a `Restforce::Collection` which is an Enumerable. This allows `SObject.build` to behave as expected when that test is run.
