### PR TITLE
removed awfully unnecessary include.

### DIFF
--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -13,7 +13,6 @@ module ActiveForce
     include ActiveAttr::Model
     include ActiveAttr::Dirty
     include ActiveForce::Association
-    include StandardTypes
 
     class_attribute :mappings, :table_name
 


### PR DESCRIPTION
now sobject class is an A again in codeclimate :+1: 
