### PR TITLE
Fix SObject#attributes_for_sfdb_create and #attributes_for_sfdb_update

### DIFF
--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -173,7 +173,7 @@ module ActiveForce
         value = read_attribute(attr)
         [sf_field, value] if value
       end
-      Hash.new(attrs.compact)
+      Hash[attrs.compact]
     end
 
 
@@ -181,7 +181,7 @@ module ActiveForce
       attrs = changed_mappings.map do |attr, sf_field|
         [sf_field, read_attribute(attr)]
       end
-      Hash.new(attrs).merge('Id' => id)
+      Hash[attrs].merge('Id' => id)
     end
 
     def changed_mappings

--- a/spec/active_force/callbacks_spec.rb
+++ b/spec/active_force/callbacks_spec.rb
@@ -11,7 +11,7 @@ describe ActiveForce::SObject do
   describe "save" do
 
     it 'call action callback when save a record' do
-      class Whizbang
+      class Whizbanged < ActiveForce::SObject
 
         field :updated_from
         field :dirty_attribute
@@ -31,12 +31,12 @@ describe ActiveForce::SObject do
 
       end
 
-      whizbang = Whizbang.new
-      whizbang.save
-      expect(whizbang.updated_from).to eq 'Rails'
-      expect(whizbang.dirty_attribute).to eq true
-      expect(whizbang.changed.include? 'dirty_attribute').to eq true
-      expect(whizbang.changed.include? 'updated_from').to eq false
+      whizbanged = Whizbanged.new
+      whizbanged.save
+      expect(whizbanged.updated_from).to eq 'Rails'
+      expect(whizbanged.dirty_attribute).to eq true
+      expect(whizbanged.changed.include? 'dirty_attribute').to eq true
+      expect(whizbanged.changed.include? 'updated_from').to eq false
     end
   end
 end

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -60,11 +60,15 @@ describe ActiveForce::SObject do
   describe '#update' do
 
     subject do
-      Whizbang.new
+      Whizbang.new(id: '1')
     end
 
     before do
-      expect(client).to receive(:update!).and_return('id')
+      expected_args = [
+        Whizbang.table_name,
+        {'Text_Label' => 'some text', 'Id' => '1'}
+      ]
+      expect(client).to receive(:update!).with(*expected_args).and_return('id')
     end
 
     it 'delegates to the Client with create!' do
@@ -97,7 +101,7 @@ describe ActiveForce::SObject do
   describe 'self.create' do
 
     before do
-      expect(client).to receive(:create!).and_return('id')
+      expect(client).to receive(:create!).with(Whizbang.table_name, 'Text_Label' => 'some text').and_return('id')
     end
 
     it 'should create a new instance' do


### PR DESCRIPTION
`SObject#attributes_for_sfdb_create` and `SObject#attributes_for_sfdb_update` were returning an empty hash without this patch. But I think that may have been my fault originally:)
