### PR TITLE
Fix false-negative in SObject#persisted?

### DIFF
--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -134,7 +134,7 @@ module ActiveForce
     end
 
     def persisted?
-      id?
+      !!id
     end
 
     def self.field field_name, args = {}

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -195,4 +195,22 @@ describe ActiveForce::SObject do
       expect(territory.reload).to eql expected
     end
   end
+
+  describe '#persisted?' do
+    context 'with an id' do
+      let(:instance){ Territory.new(id: '00QV0000004jeqNMAT') }
+
+      it 'returns true' do
+        expect(instance).to be_persisted
+      end
+    end
+
+    context 'without an id' do
+      let(:instance){ Territory.new }
+
+      it 'returns false' do
+        expect(instance).to_not be_persisted
+      end
+    end
+  end
 end


### PR DESCRIPTION
It seems that the current implementation of `persisted?` can return false erroneously. See the included test.
