### PR TITLE
Fix not sending `false` booleans.

### DIFF
--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -170,11 +170,18 @@ module ActiveForce
     end
 
     def attributes_for_sfdb
-      attrs = mappings.map do |attr, sf_field|
-        value = read_value(attr)
-        [sf_field, value] if value
+      if persisted?
+        attrs = changed_mappings.map do |attr, sf_field|
+          value = read_value(attr)
+          [sf_field, value]
+        end
+        attrs << ['Id', id]
+      else
+        attrs = mappings.map do |attr, sf_field|
+          value = read_value(attr)
+          [sf_field, value] unless value.nil?
+        end
       end
-      attrs << ['Id', id] if persisted?
       Hash[attrs.compact]
     end
 

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -92,13 +92,13 @@ describe ActiveForce::SObject do
     before do
       expected_args = [
         Whizbang.table_name,
-        {'Text_Label' => 'some text', 'Id' => '1'}
+        {'Text_Label' => 'some text', 'Boolean_Label' => false, 'Id' => '1'}
       ]
       expect(client).to receive(:update!).with(*expected_args).and_return('id')
     end
 
     it 'delegates to the Client with create!' do
-      expect(subject.update({ text: 'some text' })).to be_a Whizbang
+      expect(subject.update({ text: 'some text', boolean: false })).to be_a Whizbang
     end
 
   end

--- a/spec/support/whizbang.rb
+++ b/spec/support/whizbang.rb
@@ -6,6 +6,7 @@ class Whizbang < ActiveForce::SObject
   field :date,                 from: 'Date_Label'
   field :datetime,             from: 'DateTime_Label'
   field :picklist_multiselect, from: 'Picklist_Multiselect_Label'
+  field :boolean,              from: 'Boolean_Label'
   field :estimated_close_date
 
 end


### PR DESCRIPTION
When a value is explicitly set to 'false' or 'nil', it is not being sent in the request params. Test included.
