### PR TITLE
Fix bug in error logging during persistence.

### DIFF
--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -70,7 +70,7 @@ module ActiveForce
         update_attributes! attributes
       end
     rescue Faraday::Error::ClientError => error
-      logger_output __method__
+      logger_output __method__, error, attributes
     end
 
     alias_method :update, :update_attributes
@@ -87,7 +87,7 @@ module ActiveForce
         create!
       end
     rescue Faraday::Error::ClientError => error
-      logger_output __method__
+      logger_output __method__, error, attributes_for_sfdb
     end
 
     def destroy
@@ -115,7 +115,8 @@ module ActiveForce
     def save!
       save
     rescue Faraday::Error::ClientError => error
-      logger_output __method__
+      puts 'rescuing save!'
+      logger_output __method__, error, attributes_for_sfdb
     end
 
     def to_param
@@ -156,10 +157,10 @@ module ActiveForce
       @association_cache ||= {}
     end
 
-    def logger_output action
+    def logger_output action, exception, params = {}
       logger = Logger.new(STDOUT)
-      logger.info("[SFDC] [#{self.class.model_name}] [#{self.class.table_name}] Error while #{ action }, params: #{hash}, error: #{error.inspect}")
-      errors[:base] << error.message
+      logger.info("[SFDC] [#{self.class.model_name}] [#{self.class.table_name}] Error while #{ action }, params: #{params}, error: #{exception.inspect}")
+      errors[:base] << exception.message
       false
     end
 

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -17,7 +17,6 @@ describe ActiveForce::SObject do
   end
 
   describe ".build" do
-
     it "build a valid sobject from a JSON" do
       expect(Whizbang.build sobject_hash).to be_an_instance_of Whizbang
     end
@@ -210,6 +209,19 @@ describe ActiveForce::SObject do
       it 'returns false' do
         expect(instance).to_not be_persisted
       end
+    end
+  end
+
+  describe 'logger output' do
+    let(:instance){ Whizbang.new }
+
+    before do
+      allow(instance).to receive(:create!).and_raise(Faraday::Error::ClientError.new(double))
+    end
+
+    it 'catches and logs the error' do
+      expect(instance).to receive(:logger_output).and_return(false)
+      instance.save
     end
   end
 end


### PR DESCRIPTION
I noticed that when getting errors back from Salesforce, I always got this NameError about "error." After digging into the code and the revision history, it seems this method was pulled out during a refactoring and over time, it was broken.

I've reworked the method so that it doesn't error anymore and added a spec.
