### PR TITLE
Better typecasting when building SObjects

### DIFF
--- a/lib/active_force/mapping.rb
+++ b/lib/active_force/mapping.rb
@@ -6,6 +6,12 @@ module ActiveForce
   class Mapping
     extend Forwardable
 
+    STRINGLIKE_TYPES = [
+      nil, :string, :base64, :byte, :ID, :reference, :currency, :textarea,
+      :phone, :url, :email, :combobox, :picklist, :multipicklist, :anyType,
+      :location
+    ]
+
     def_delegators :table, :custom_table?, :table_name
 
     def initialize model
@@ -36,11 +42,37 @@ module ActiveForce
       Hash[attrs]
     end
 
+    def translate_value value, field_name
+      return value unless !!field_name
+      typecast_value value.to_s, fields[field_name].as
+    end
+
+
     private
 
     def fields
       @fields ||= {}
     end
 
+    # Handles Salesforce FieldTypes as described here:
+    # http://www.salesforce.com/us/developer/docs/api/Content/sforce_api_calls_describesobjects_describesobjectresult.htm#i1427700
+    def typecast_value value, type
+      case type
+      when *STRINGLIKE_TYPES
+        value
+      when :boolean
+        !['false','0','f'].include? value.downcase
+      when :int
+        value.to_i
+      when :double, :percent
+        value.to_f
+      when :date
+        Date.parse value
+      when :datetime
+        DateTime.parse value
+      else
+        value
+      end
+    end
   end
 end

--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -147,6 +147,7 @@ module ActiveForce
         value = association.relation_model.build value
       else
         field = mappings.invert[column]
+        value = self.class.mapping.translate_value value, field unless value.nil?
       end
       send "#{field}=", value if field
     end

--- a/spec/active_force/callbacks_spec.rb
+++ b/spec/active_force/callbacks_spec.rb
@@ -11,27 +11,7 @@ describe ActiveForce::SObject do
   describe "save" do
 
     it 'call action callback when save a record' do
-      class Whizbanged < ActiveForce::SObject
-
-        field :updated_from
-        field :dirty_attribute
-
-        before_save :set_as_updated_from_rails
-        after_save :mark_dirty
-
-        private
-
-        def set_as_updated_from_rails
-          self.updated_from = 'Rails'
-        end
-
-        def mark_dirty
-          self.dirty_attribute = true
-        end
-
-      end
-
-      whizbanged = Whizbanged.new
+      whizbanged = Whizbang.new
       whizbanged.save
       expect(whizbanged.updated_from).to eq 'Rails'
       expect(whizbanged.dirty_attribute).to eq true

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -17,8 +17,20 @@ describe ActiveForce::SObject do
   end
 
   describe ".build" do
+    let(:sobject){ Whizbang.build sobject_hash }
+
     it "build a valid sobject from a JSON" do
-      expect(Whizbang.build sobject_hash).to be_an_instance_of Whizbang
+      expect(sobject).to be_an_instance_of Whizbang
+    end
+
+    it "sets the values' types from the sf_type" do
+      expect(sobject.boolean).to be_an_instance_of TrueClass
+      expect(sobject.checkbox).to be_an_instance_of FalseClass
+      expect(sobject.date).to be_an_instance_of Date
+      expect(sobject.datetime).to be_an_instance_of DateTime
+      expect(sobject.percent).to be_an_instance_of Float
+      expect(sobject.text).to be_an_instance_of String
+      expect(sobject.picklist_multiselect).to be_an_instance_of String
     end
   end
 
@@ -125,7 +137,7 @@ describe ActiveForce::SObject do
 
     describe 'self.create' do
       before do
-        expect(client).to receive(:create!).with(Whizbang.table_name, 'Text_Label' => 'some text').and_return('id')
+        expect(client).to receive(:create!).with(Whizbang.table_name, 'Text_Label' => 'some text', 'Updated_From__c'=>'Rails').and_return('id')
       end
 
       it 'should create a new instance' do

--- a/spec/fixtures/sobject/single_sobject_hash.yml
+++ b/spec/fixtures/sobject/single_sobject_hash.yml
@@ -6,6 +6,8 @@ Text_Label: 'Hi there!'
 Date_Label: '2010-01-01'
 DateTime_Label: '2011-07-07T00:37:00.000+0000'
 Picklist_Multiselect_Label: 'four;six'
+Percent_Label: 20
+Boolean_Label: true
 
 ParentWhizbang__r:
   Name: 'Parent Whizbang'

--- a/spec/support/whizbang.rb
+++ b/spec/support/whizbang.rb
@@ -1,12 +1,29 @@
 class Whizbang < ActiveForce::SObject
 
   field :id,                   from: 'Id'
-  field :checkbox,             from: 'Checkbox_Label'
+  field :checkbox,             from: 'Checkbox_Label', as: :boolean
   field :text,                 from: 'Text_Label'
-  field :date,                 from: 'Date_Label'
-  field :datetime,             from: 'DateTime_Label'
-  field :picklist_multiselect, from: 'Picklist_Multiselect_Label'
-  field :boolean,              from: 'Boolean_Label'
-  field :estimated_close_date
+  field :date,                 from: 'Date_Label', as: :date
+  field :datetime,             from: 'DateTime_Label', as: :datetime
+  field :picklist_multiselect, from: 'Picklist_Multiselect_Label', as: :multipicklist
+  field :boolean,              from: 'Boolean_Label',  as: :boolean
+  field :percent,              from: 'Percent_Label',  as: :percent
+  field :estimated_close_date, as: :datetime
+  field :updated_from,         as: :datetime
+  field :dirty_attribute,      as: :boolean
+
+  before_save :set_as_updated_from_rails
+  after_save :mark_dirty
+
+
+  private
+
+  def set_as_updated_from_rails
+    self.updated_from = 'Rails'
+  end
+
+  def mark_dirty
+    self.dirty_attribute = true
+  end
 
 end


### PR DESCRIPTION
Cast values based on their declared Salesforce FieldTypes when building SObjects from a response.
