### PR TITLE
Fix includes for namespaced SObjects

### DIFF
--- a/lib/active_force/association.rb
+++ b/lib/active_force/association.rb
@@ -4,16 +4,14 @@ require 'active_force/association/belongs_to_association'
 
 module ActiveForce
   module Association
-
     def associations
       @associations ||= {}
     end
 
     # i.e name = 'Quota__r'
     def find_association name
-      name = name.gsub "__r", ""
       associations.values.detect do |association|
-        association.relation_model.name == name
+        association.represents_sfdc_table? name
       end
     end
 
@@ -24,6 +22,5 @@ module ActiveForce
     def belongs_to relation_name, options = {}
       associations[relation_name] = BelongsToAssociation.new(self, relation_name, options)
     end
-
   end
 end

--- a/lib/active_force/association/association.rb
+++ b/lib/active_force/association/association.rb
@@ -19,6 +19,15 @@ module ActiveForce
         @options[:foreign_key] || default_foreign_key
       end
 
+      ###
+      # Does this association's relation_model represent
+      # +sfdc_table_name+? Examples of +sfdc_table_name+
+      # could be 'Quota__r' or 'Account'.
+      def represents_sfdc_table?(sfdc_table_name)
+        name = sfdc_table_name.sub /__r\z/, ''
+        relation_model.table_name.sub(/__c\z/, '') == name
+      end
+
       private
 
       def build

--- a/lib/active_force/association/belongs_to_association.rb
+++ b/lib/active_force/association/belongs_to_association.rb
@@ -1,12 +1,12 @@
 module ActiveForce
   module Association
-
     class BelongsToAssociation < Association
-
       def sfdc_association_field
-        sfdc_field = relation_model.name
-        sfdc_field += "__r" if relation_model.custom_table?
-        sfdc_field
+        if relation_model.custom_table?
+          relation_model.table_name.gsub(/__c\z/, '__r')
+        else
+          relation_model.name
+        end
       end
 
       private
@@ -30,6 +30,5 @@ module ActiveForce
         end
       end
     end
-
   end
 end

--- a/spec/active_force/sobject/includes_spec.rb
+++ b/spec/active_force/sobject/includes_spec.rb
@@ -16,17 +16,65 @@ module ActiveForce
         end
 
         it "queries the API once to retrieve the object and its related one" do
-          response = [{ 
-            "Id" => "123", 
-            "Quota__c" => "321", 
-            "Quota__r" => { 
-              "Bar_Id__c" => "321" 
-            } 
+          response = [{
+            "Id"       => "123",
+            "Quota__c" => "321",
+            "Quota__r" => {
+              "Bar_Id__c" => "321"
+            }
           }]
           allow(client).to receive(:query).once.and_return response
           territory = Territory.includes(:quota).find "123"
           expect(territory.quota).to be_a Quota
           expect(territory.quota.id).to eq "321"
+        end
+
+        context 'with namespaced SObjects' do
+          it 'queries the API for the associated record' do
+            soql = Salesforce::Territory.includes(:quota).where(id: '123').to_s
+            expect(soql).to eq "SELECT Id, QuotaId, WidgetId, Quota__r.Id FROM Territory WHERE Id = '123'"
+          end
+
+          it "queries the API once to retrieve the object and its related one" do
+            response = [{
+              "Id"       => "123",
+              "QuotaId"  => "321",
+              "WidgetId" => "321",
+              "Quota__r" => {
+                "Id" => "321"
+              }
+            }]
+            allow(client).to receive(:query).once.and_return response
+            territory = Salesforce::Territory.includes(:quota).find "123"
+            expect(territory.quota).to be_a Salesforce::Quota
+            expect(territory.quota.id).to eq "321"
+          end
+
+          context 'when the class name does not match the SFDC entity name' do
+            let(:expected_soql) do
+              "SELECT Id, QuotaId, WidgetId, Tegdiw__r.Id FROM Territory WHERE Id = '123'"
+            end
+
+            it 'queries the API for the associated record' do
+              soql = Salesforce::Territory.includes(:widget).where(id: '123').to_s
+              expect(soql).to eq expected_soql
+            end
+
+            it "queries the API once to retrieve the object and its related one" do
+              response = [{
+                "Id"        => "123",
+                "WidgetId"  => "321",
+                "Tegdiw__r" => {
+                  "Id" => "321"
+                }
+              }]
+              expected = expected_soql + ' LIMIT 1'
+              allow(client).to receive(:query).once.with(expected).and_return response
+              territory = Salesforce::Territory.includes(:widget).find "123"
+              expect(territory.widget).to be_a Salesforce::Widget
+              expect(territory.widget.id).to eq "321"
+            end
+          end
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,3 +23,17 @@ class Quota < ActiveForce::SObject
   has_many :territories
 end
 
+module Salesforce
+  class Quota < ActiveForce::SObject
+  end
+  class Widget < ActiveForce::SObject
+    self.table_name = 'Tegdiw__c'
+  end
+  class Territory < ActiveForce::SObject
+    field :quota_id, from: "QuotaId"
+    field :widget_id, from: 'WidgetId'
+    belongs_to :quota, model: Salesforce::Quota, foreign_key: :quota_id
+    belongs_to :widget, model: Salesforce::Widget, foreign_key: :widget_id
+  end
+end
+


### PR DESCRIPTION
`SObject#includes` wasn't working for namespaced SObjects because it was relying on the class' name to build the SOQL relationship query.
