### PR TITLE
Don't use SObject.custom_table? to infer BelongsToAssociation#sfdc_assoc...

### DIFF
--- a/lib/active_force/association/belongs_to_association.rb
+++ b/lib/active_force/association/belongs_to_association.rb
@@ -2,11 +2,7 @@ module ActiveForce
   module Association
     class BelongsToAssociation < Association
       def sfdc_association_field
-        if relation_model.custom_table?
-          relation_model.table_name.gsub(/__c\z/, '__r')
-        else
-          relation_model.name
-        end
+        relation_model.table_name.gsub /__c\z/, '__r'
       end
 
       private

--- a/spec/active_force/sobject/includes_spec.rb
+++ b/spec/active_force/sobject/includes_spec.rb
@@ -46,76 +46,99 @@ module ActiveForce
         end
 
         context 'with namespaced SObjects' do
-          it 'queries the API for the associated record' do
-            soql = Salesforce::Territory.includes(:quota).where(id: '123').to_s
-            expect(soql).to eq "SELECT Id, QuotaId, WidgetId, Quota__r.Id FROM Territory WHERE Id = '123'"
-          end
-
-          it "queries the API once to retrieve the object and its related one" do
-            response = [{
-              "Id"       => "123",
-              "QuotaId"  => "321",
-              "WidgetId" => "321",
-              "Quota__r" => {
-                "Id" => "321"
-              }
-            }]
-            allow(client).to receive(:query).once.and_return response
-            territory = Salesforce::Territory.includes(:quota).find "123"
-            expect(territory.quota).to be_a Salesforce::Quota
-            expect(territory.quota.id).to eq "321"
-          end
-
-          context 'when the class name does not match the SFDC entity name' do
-            let(:expected_soql) do
-              "SELECT Id, QuotaId, WidgetId, Tegdiw__r.Id FROM Territory WHERE Id = '123'"
-            end
-
+          context 'with standard objects' do
             it 'queries the API for the associated record' do
-              soql = Salesforce::Territory.includes(:widget).where(id: '123').to_s
-              expect(soql).to eq expected_soql
+              soql = Salesforce::Opportunity.includes(:account).where(id: '123').to_s
+              expect(soql).to eq "SELECT Id, AccountId, Account.Id FROM Opportunity WHERE Id = '123'"
             end
 
             it "queries the API once to retrieve the object and its related one" do
               response = [{
                 "Id"        => "123",
-                "WidgetId"  => "321",
-                "Tegdiw__r" => {
+                "AccountId" => "321",
+                "Account"   => {
                   "Id" => "321"
                 }
               }]
-              expected = expected_soql + ' LIMIT 1'
-              allow(client).to receive(:query).once.with(expected).and_return response
-              territory = Salesforce::Territory.includes(:widget).find "123"
-              expect(territory.widget).to be_a Salesforce::Widget
-              expect(territory.widget.id).to eq "321"
+              allow(client).to receive(:query).once.and_return response
+              opportunity = Salesforce::Opportunity.includes(:account).find "123"
+              expect(opportunity.account).to be_a Salesforce::Account
+              expect(opportunity.account.id).to eq "321"
             end
           end
 
-          context 'child to several parents' do
-            it 'queries the API for associated records' do
-              soql = Salesforce::Territory.includes(:quota, :widget).where(id: '123').to_s
-              expect(soql).to eq "SELECT Id, QuotaId, WidgetId, Quota__r.Id, Tegdiw__r.Id FROM Territory WHERE Id = '123'"
+          context 'with custom Salesforce objects' do
+            it 'queries the API for the associated record' do
+              soql = Salesforce::Territory.includes(:quota).where(id: '123').to_s
+              expect(soql).to eq "SELECT Id, QuotaId, WidgetId, Quota__r.Id FROM Territory WHERE Id = '123'"
             end
 
-            it "queries the API once to retrieve the object and its assocations" do
+            it "queries the API once to retrieve the object and its related one" do
               response = [{
                 "Id"       => "123",
                 "QuotaId"  => "321",
                 "WidgetId" => "321",
                 "Quota__r" => {
                   "Id" => "321"
-                },
-                "Tegdiw__r" => {
-                  "Id" => "321"
                 }
               }]
               allow(client).to receive(:query).once.and_return response
-              territory = Salesforce::Territory.includes(:quota, :widget).find "123"
+              territory = Salesforce::Territory.includes(:quota).find "123"
               expect(territory.quota).to be_a Salesforce::Quota
               expect(territory.quota.id).to eq "321"
-              expect(territory.widget).to be_a Salesforce::Widget
-              expect(territory.widget.id).to eq "321"
+            end
+
+            context 'when the class name does not match the SFDC entity name' do
+              let(:expected_soql) do
+                "SELECT Id, QuotaId, WidgetId, Tegdiw__r.Id FROM Territory WHERE Id = '123'"
+              end
+
+              it 'queries the API for the associated record' do
+                soql = Salesforce::Territory.includes(:widget).where(id: '123').to_s
+                expect(soql).to eq expected_soql
+              end
+
+              it "queries the API once to retrieve the object and its related one" do
+                response = [{
+                  "Id"        => "123",
+                  "WidgetId"  => "321",
+                  "Tegdiw__r" => {
+                    "Id" => "321"
+                  }
+                }]
+                expected = expected_soql + ' LIMIT 1'
+                allow(client).to receive(:query).once.with(expected).and_return response
+                territory = Salesforce::Territory.includes(:widget).find "123"
+                expect(territory.widget).to be_a Salesforce::Widget
+                expect(territory.widget.id).to eq "321"
+              end
+            end
+
+            context 'child to several parents' do
+              it 'queries the API for associated records' do
+                soql = Salesforce::Territory.includes(:quota, :widget).where(id: '123').to_s
+                expect(soql).to eq "SELECT Id, QuotaId, WidgetId, Quota__r.Id, Tegdiw__r.Id FROM Territory WHERE Id = '123'"
+              end
+
+              it "queries the API once to retrieve the object and its assocations" do
+                response = [{
+                  "Id"       => "123",
+                  "QuotaId"  => "321",
+                  "WidgetId" => "321",
+                  "Quota__r" => {
+                    "Id" => "321"
+                  },
+                  "Tegdiw__r" => {
+                    "Id" => "321"
+                  }
+                }]
+                allow(client).to receive(:query).once.and_return response
+                territory = Salesforce::Territory.includes(:quota, :widget).find "123"
+                expect(territory.quota).to be_a Salesforce::Quota
+                expect(territory.quota.id).to eq "321"
+                expect(territory.widget).to be_a Salesforce::Widget
+                expect(territory.widget.id).to eq "321"
+              end
             end
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,5 +35,11 @@ module Salesforce
     belongs_to :quota, model: Salesforce::Quota, foreign_key: :quota_id
     belongs_to :widget, model: Salesforce::Widget, foreign_key: :widget_id
   end
+  class Account < ActiveForce::SObject
+  end
+  class Opportunity < ActiveForce::SObject
+    field :account_id, from: 'AccountId'
+    belongs_to :account, model: Account
+  end
 end
 


### PR DESCRIPTION
...iation_field. It's already handled in ActiveForce::Table

This fixes a bug where using `includes` on relationships of namespaced SObjects would generate invalid SOQL. The namespace was being included in the table name in the query erroneously. ex `SELECT Id, Salesforce::Account.Id FROM Opportunity ...`
