### PR TITLE
Correctly infer foreign_key from associations with multi-word model classes

### DIFF
--- a/lib/active_force/association/association.rb
+++ b/lib/active_force/association/association.rb
@@ -42,7 +42,7 @@ module ActiveForce
 
       def infer_foreign_key_from_model(model)
         name = model.custom_table? ? model.name : model.table_name
-        "#{name.downcase}_id".to_sym
+        name.foreign_key.to_sym
       end
     end
 


### PR DESCRIPTION
Allows associations with SObject subclasses like 'ActionItem' to correctly infer a foreign key of 'action_item_id' instead of 'actionitem_id'.
