### PR TITLE
Allow sfdc_client to be set with a configuration option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ environment variables to set up credentials.
 
 You might be interested in [dotenv-rails][3] to set up those in development.
 
+Also, you may specify your client as a configuration option, which is useful
+when having to reauthenticate utilizing oauth.
+
+```ruby
+ActiveForce.configuration.sfdc_client = Restforce.new(
+  oauth_token:         current_user.oauth_token,
+  refresh_token:       current_user.refresh_token,
+  instance_url:        current_user.instance_url,
+  client_id:           SALESFORCE_CLIENT_ID,
+  client_secret:       SALESFORCE_CLIENT_SECRET
+)
+```
+
 ## Usage
 
 ```ruby

--- a/lib/active_force.rb
+++ b/lib/active_force.rb
@@ -1,6 +1,16 @@
 require 'active_force/version'
 require 'active_force/sobject'
 require 'active_force/query'
+require 'active_force/configuration'
 
 module ActiveForce
+  extend self
+
+  def configure
+    yield configuration
+  end
+
+  def configuration
+    @configuration ||= Configuration.new
+  end
 end

--- a/lib/active_force/configuration.rb
+++ b/lib/active_force/configuration.rb
@@ -1,0 +1,11 @@
+module ActiveForce
+  class Configuration
+    attr_accessor :sfdc_client
+
+    private
+
+    def initialize
+      @sfdc_client ||= Restforce.new
+    end
+  end
+end

--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -199,7 +199,7 @@ module ActiveForce
     end
 
     def self.sfdc_client
-      @client ||= Restforce.new
+      ActiveForce.configuration.sfdc_client
     end
 
     def sfdc_client

--- a/spec/active_force/association_spec.rb
+++ b/spec/active_force/association_spec.rb
@@ -14,7 +14,7 @@ describe ActiveForce::SObject do
   end
 
   before do
-    allow(ActiveForce::SObject).to receive(:sfdc_client).and_return client
+    ActiveForce.configuration.sfdc_client = client
   end
 
   describe "has_many_query" do

--- a/spec/active_force/callbacks_spec.rb
+++ b/spec/active_force/callbacks_spec.rb
@@ -4,7 +4,7 @@ describe ActiveForce::SObject do
   let(:client) { double 'Client', create!: 'id' }
 
   before do
-    allow(ActiveForce::SObject).to receive(:sfdc_client).and_return client
+    ActiveForce.configuration.sfdc_client = client
   end
 
   describe "save" do

--- a/spec/active_force/sobject/includes_spec.rb
+++ b/spec/active_force/sobject/includes_spec.rb
@@ -5,7 +5,7 @@ module ActiveForce
     let(:client){ double "client" }
 
     before do
-      allow(ActiveForce::SObject).to receive(:sfdc_client).and_return client
+      ActiveForce.configuration.sfdc_client = client
     end
 
     describe '.includes' do

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -5,7 +5,7 @@ describe ActiveForce::SObject do
   let(:client) { double 'Client' }
 
   before do
-    allow(ActiveForce::SObject).to receive(:sfdc_client).and_return client
+    ActiveForce.configuration.sfdc_client = client
   end
 
   describe ".new" do
@@ -264,7 +264,7 @@ describe ActiveForce::SObject do
     let(:territory){ Territory.new(id: '1', quota_id: '1') }
 
     before do
-      allow(ActiveForce::SObject).to receive(:sfdc_client).and_return client
+      ActiveForce.configuration.sfdc_client = client
     end
 
     it 'clears cached associations' do


### PR DESCRIPTION
This allows OAuth authentication, and also prevents having to authenticate a client for each class.
