### PR TITLE
Add support for compound field and others non-stringlike_types fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ class Medication < ActiveForce::SObject
 
   field :max_dossage  # defaults to "Max_Dossage__c"
   field :updated_from
- 
+
   ##
   # You can cast field value using `as`
   # field :address_primary_active, from: 's360a__AddressPrimaryActive__c', as: :boolean
-  # 
-  # Available options are :boolean, :int, :double, :percent, :date, :datetime, :string, :base64, 
-  # :byte, :ID, :reference, :currency, :textarea, :phone, :url, :email, :combobox, :picklist, 
-  # :multipicklist, :anyType, :location
+  #
+  # Available options are :boolean, :int, :double, :percent, :date, :datetime, :string, :base64,
+  # :byte, :ID, :reference, :currency, :textarea, :phone, :url, :email, :combobox, :picklist,
+  # :multipicklist, :anyType, :location, :compound
 
   ##
   # Table name is inferred from class name.

--- a/lib/active_force/mapping.rb
+++ b/lib/active_force/mapping.rb
@@ -44,7 +44,7 @@ module ActiveForce
 
     def translate_value value, field_name
       return value unless !!field_name
-      typecast_value value.to_s, fields[field_name].as
+      typecast_value value, fields[field_name].as
     end
 
 
@@ -59,7 +59,7 @@ module ActiveForce
     def typecast_value value, type
       case type
       when *STRINGLIKE_TYPES
-        value
+        value.to_s
       when :boolean
         !['false','0','f'].include? value.downcase
       when :int


### PR DESCRIPTION
This PR fix #99 .

By default, we should not change a value of a field to a string, that's why i was unable to use compound fields from salesforce.

