### PR TITLE
Apply scoped_as option when eager loading associations

### DIFF
--- a/lib/active_force/active_query.rb
+++ b/lib/active_force/active_query.rb
@@ -33,12 +33,6 @@ module ActiveForce
       limit == 1 ? to_a.first : self
     end
 
-    def where args=nil, *rest
-      return self if args.nil?
-      super build_condition args, rest
-      self
-    end
-
     def select *fields
       fields.map! { |field| mappings[field] }
       super *fields
@@ -62,91 +56,6 @@ module ActiveForce
     end
 
     private
-
-    def build_condition(args, other=[])
-      case args
-      when String, Array
-        build_condition_from_array other.empty? ? args : ([args] + other)
-      when Hash
-        build_conditions_from_hash args
-      else
-        args
-      end
-    end
-
-    def build_condition_from_array(ary)
-      statement, *bind_parameters = ary
-      return statement if bind_parameters.empty?
-      if bind_parameters.first.is_a? Hash
-        replace_named_bind_parameters statement, bind_parameters.first
-      else
-        replace_bind_parameters statement, bind_parameters
-      end
-    end
-
-    def replace_named_bind_parameters(statement, bind_parameters)
-      statement.gsub(/(:?):([a-zA-Z]\w*)/) do
-        key = $2.to_sym
-        if bind_parameters.has_key? key
-          enclose_value bind_parameters[key]
-        else
-          raise PreparedStatementInvalid, "missing value for :#{key} in #{statement}"
-        end
-      end
-    end
-
-    def replace_bind_parameters(statement, values)
-      raise_if_bind_arity_mismatch statement.count('?'), values.size
-      bound = values.dup
-      statement.gsub('?') do
-        enclose_value bound.shift
-      end
-    end
-
-    def raise_if_bind_arity_mismatch(expected_var_count, actual_var_count)
-      if expected_var_count != actual_var_count
-        raise PreparedStatementInvalid, "wrong number of bind variables (#{actual_var_count} for #{expected_var_count})"
-      end
-    end
-
-    def build_conditions_from_hash(hash)
-      hash.map do |key, value|
-        applicable_predicate mappings[key], value
-      end
-    end
-
-    def applicable_predicate(attribute, value)
-      if value.is_a? Array
-        in_predicate attribute, value
-      else
-        eq_predicate attribute, value
-      end
-    end
-
-    def in_predicate(attribute, values)
-      escaped_values = values.map &method(:enclose_value)
-      "#{attribute} IN (#{escaped_values.join(',')})"
-    end
-
-    def eq_predicate(attribute, value)
-      "#{attribute} = #{enclose_value value}"
-    end
-
-    def enclose_value value
-      case value
-      when String
-        "'#{quote_string(value)}'"
-      when NilClass
-        'NULL'
-      else
-        value.to_s
-      end
-    end
-
-    def quote_string(s)
-      # From activerecord/lib/active_record/connection_adapters/abstract/quoting.rb, version 4.1.5, line 82
-      s.gsub(/\\/, '\&\&').gsub(/'/, "''")
-    end
 
     def result
       sfdc_client.query(self.to_s)

--- a/lib/active_force/association/eager_load_projection_builder.rb
+++ b/lib/active_force/association/eager_load_projection_builder.rb
@@ -44,6 +44,7 @@ module ActiveForce
         # pluralize the table name, and append '__r' if it was there to begin with
         relationship_name = association.sfdc_association_field.sub(match.to_s, '').pluralize + match.to_s
         query = Query.new relationship_name
+        association.apply_scope query
         query.fields association.relation_model.fields
         ["(#{query.to_s})"]
       end

--- a/lib/active_force/association/eager_load_projection_builder.rb
+++ b/lib/active_force/association/eager_load_projection_builder.rb
@@ -44,7 +44,13 @@ module ActiveForce
         # pluralize the table name, and append '__r' if it was there to begin with
         relationship_name = association.sfdc_association_field.sub(match.to_s, '').pluralize + match.to_s
         query = Query.new relationship_name
-        association.apply_scope query
+        if scope = association.options[:scoped_as]
+          if scope.arity > 0
+            query.instance_exec association, &scope
+          else
+            query.instance_exec &scope
+          end
+        end
         query.fields association.relation_model.fields
         ["(#{query.to_s})"]
       end

--- a/lib/active_force/association/has_many_association.rb
+++ b/lib/active_force/association/has_many_association.rb
@@ -1,6 +1,18 @@
 module ActiveForce
   module Association
     class HasManyAssociation < Association
+
+      def apply_scope query
+        if scope = self.options[:scoped_as]
+          if scope.arity > 0
+            query.instance_exec self, &scope
+          else
+            query.instance_exec &scope
+          end
+        end
+        query
+      end
+
       private
 
       def default_foreign_key
@@ -13,13 +25,7 @@ module ActiveForce
         @parent.send :define_method, _method do
           association_cache.fetch _method do
             query = association.relation_model.query
-            if scope = association.options[:scoped_as]
-              if scope.arity > 0
-                query.instance_exec self, &scope
-              else
-                query.instance_exec &scope
-              end
-            end
+            apply_scope query
             association_cache[_method] = query.where association.foreign_key => self.id
           end
         end

--- a/lib/active_force/association/has_many_association.rb
+++ b/lib/active_force/association/has_many_association.rb
@@ -1,18 +1,6 @@
 module ActiveForce
   module Association
     class HasManyAssociation < Association
-
-      def apply_scope query
-        if scope = self.options[:scoped_as]
-          if scope.arity > 0
-            query.instance_exec self, &scope
-          else
-            query.instance_exec &scope
-          end
-        end
-        query
-      end
-
       private
 
       def default_foreign_key
@@ -25,7 +13,13 @@ module ActiveForce
         @parent.send :define_method, _method do
           association_cache.fetch _method do
             query = association.relation_model.query
-            apply_scope query
+            if scope = association.options[:scoped_as]
+              if scope.arity > 0
+                query.instance_exec self, &scope
+              else
+                query.instance_exec &scope
+              end
+            end
             association_cache[_method] = query.where association.foreign_key => self.id
           end
         end

--- a/lib/active_force/query.rb
+++ b/lib/active_force/query.rb
@@ -35,7 +35,9 @@ module ActiveForce
       self
     end
 
-    def where condition
+    def where args=nil, *rest
+      return self if args.nil?
+      condition = build_condition args, rest
       @conditions << condition if condition
       self
     end
@@ -106,5 +108,92 @@ module ActiveForce
       def build_offset
         "OFFSET #{ @offset }" if @offset
       end
+
+    private
+
+    def build_condition(args, other=[])
+      case args
+      when String, Array
+        build_condition_from_array other.empty? ? args : ([args] + other)
+      when Hash
+        build_conditions_from_hash args
+      else
+        args
+      end
+    end
+
+    def build_condition_from_array(ary)
+      statement, *bind_parameters = ary
+      return statement if bind_parameters.empty?
+      if bind_parameters.first.is_a? Hash
+        replace_named_bind_parameters statement, bind_parameters.first
+      else
+        replace_bind_parameters statement, bind_parameters
+      end
+    end
+
+    def replace_named_bind_parameters(statement, bind_parameters)
+      statement.gsub(/(:?):([a-zA-Z]\w*)/) do
+        key = $2.to_sym
+        if bind_parameters.has_key? key
+          enclose_value bind_parameters[key]
+        else
+          raise PreparedStatementInvalid, "missing value for :#{key} in #{statement}"
+        end
+      end
+    end
+
+    def replace_bind_parameters(statement, values)
+      raise_if_bind_arity_mismatch statement.count('?'), values.size
+      bound = values.dup
+      statement.gsub('?') do
+        enclose_value bound.shift
+      end
+    end
+
+    def raise_if_bind_arity_mismatch(expected_var_count, actual_var_count)
+      if expected_var_count != actual_var_count
+        raise PreparedStatementInvalid, "wrong number of bind variables (#{actual_var_count} for #{expected_var_count})"
+      end
+    end
+
+    def build_conditions_from_hash(hash)
+      hash.map do |key, value|
+        applicable_predicate mappings[key], value
+      end
+    end
+
+    def applicable_predicate(attribute, value)
+      if value.is_a? Array
+        in_predicate attribute, value
+      else
+        eq_predicate attribute, value
+      end
+    end
+
+    def in_predicate(attribute, values)
+      escaped_values = values.map &method(:enclose_value)
+      "#{attribute} IN (#{escaped_values.join(',')})"
+    end
+
+    def eq_predicate(attribute, value)
+      "#{attribute} = #{enclose_value value}"
+    end
+
+    def enclose_value value
+      case value
+      when String
+        "'#{quote_string(value)}'"
+      when NilClass
+        'NULL'
+      else
+        value.to_s
+      end
+    end
+
+    def quote_string(s)
+      # From activerecord/lib/active_record/connection_adapters/abstract/quoting.rb, version 4.1.5, line 82
+      s.gsub(/\\/, '\&\&').gsub(/'/, "''")
+    end
   end
 end


### PR DESCRIPTION
The `:scoped_as` options on `HasManyAssociation`s wasn't being applied when eager loading with `:includes`, so I took a quick stab at fixing it. 

I wasn't entirely sure when `ActiveQuery` should be used as opposed to `Query`, so let me know if these changes might cause any unintended problems. I will update the specs soon if you like these changes. 
