### PR TITLE
add activesupport/use hash_with_indifferent_access for consistent fie…

### DIFF
--- a/active_force.gemspec
+++ b/active_force.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'active_attr', '~> 0.8'
   spec.add_dependency 'restforce',   '~> 1.4'
+  spec.add_dependency 'activesupport'
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '>= 0'
   spec.add_development_dependency 'rspec', '>= 0'

--- a/lib/active_force/mapping.rb
+++ b/lib/active_force/mapping.rb
@@ -1,6 +1,7 @@
 require 'active_force/attribute'
 require 'active_force/table'
 require 'forwardable'
+require 'active_support/core_ext'
 
 module ActiveForce
   class Mapping
@@ -19,7 +20,7 @@ module ActiveForce
     end
 
     def mappings
-      Hash[fields.map { |field, attr| [field, attr.sfdc_name] }]
+      Hash[fields.map { |field, attr| [field, attr.sfdc_name] }].with_indifferent_access
     end
 
     def sfdc_names
@@ -39,7 +40,7 @@ module ActiveForce
         attr = fields[attribute.to_sym]
         [attr.sfdc_name, attr.value_for_hash(value)]
       end
-      Hash[attrs]
+      Hash[attrs].with_indifferent_access
     end
 
     def translate_value value, field_name
@@ -51,7 +52,7 @@ module ActiveForce
     private
 
     def fields
-      @fields ||= {}
+      @fields ||= {}.with_indifferent_access
     end
 
     # Handles Salesforce FieldTypes as described here:

--- a/spec/active_force/mapping_spec.rb
+++ b/spec/active_force/mapping_spec.rb
@@ -6,7 +6,7 @@ describe ActiveForce::Mapping do
   describe 'field' do
     it 'should add a new attribute to the instance' do
       mapping.field :id, from: 'Id'
-      expect(mapping.mappings).to eq({ id: 'Id' })
+      expect(mapping.mappings).to eq({ 'id' => 'Id' })
     end
 
     it 'sf_names should return all attributes names from salesforce' do


### PR DESCRIPTION
addresses #110 , will treat symbol/string field names when mapping fields the same, without breaking somewhat silently. (Silently as in it's not an issue until you try to create/save)
