### PR TITLE
Updated restforce version to be able to use active force with Rails 5

### DIFF
--- a/active_force.gemspec
+++ b/active_force.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_dependency 'active_attr', '~> 0.8'
-  spec.add_dependency 'restforce',   '~> 1.4'
+  spec.add_dependency 'restforce',   '>= 1.4'
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '>= 0'
   spec.add_development_dependency 'rspec', '>= 0'

--- a/active_force.gemspec
+++ b/active_force.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_dependency 'active_attr', '~> 0.8'
-  spec.add_dependency 'restforce',   '>= 1.4'
+  spec.add_dependency 'restforce',   '>= 2.0'
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '>= 0'
   spec.add_development_dependency 'rspec', '>= 0'


### PR DESCRIPTION
Note: add to gemfile

`gem 'json' , '< 1.9.0'`
